### PR TITLE
feat: Add Android Firefox 115

### DIFF
--- a/__test__/browserslist.test.ts
+++ b/__test__/browserslist.test.ts
@@ -30,6 +30,7 @@ describe('Browserslist', () => {
     // The expected browsers
     const expectedBrowsers = [
       'and_chr 132',
+      'and_ff 132',
       'chrome 109',
       'chrome 110',
       'chrome 111',

--- a/browserslist.cjs
+++ b/browserslist.cjs
@@ -5,6 +5,7 @@ module.exports = [
   'opera >= 95',
   'safari >= 13.1',
   'ChromeAndroid >= 106',
+  'FirefoxAndroid >= 115',
   'samsung >= 17',
   'iOS >= 13.1',
 ]


### PR DESCRIPTION
Proposal to add Firefox 115 on Android to the list. The list has Firefox 115 on Desktop, so it should not be a big deal, but this move increase general coverage on [browserslist](https://browsersl.ist/) by 0.4% Norway audience.

With: 96.4% [link](https://browsersl.ist/#q=Chrome+%3E%3D+109%2C+Firefox+%3E%3D+115%2C+Edge+%3E%3D+109%2C+Opera+%3E%3D+95%2C+Safari+%3E%3D+13.1%2C+ChromeAndroid+%3E%3D+106%2C+FirefoxAndroid+%3E%3D+115%2C+Samsung+%3E%3D+17%2C+iOS+%3E%3D+13.1&region=NO)
Without: 96% [link](https://browsersl.ist/#q=Chrome+%3E%3D+109%2C+Firefox+%3E%3D+115%2C+Edge+%3E%3D+109%2C+Opera+%3E%3D+95%2C+Safari+%3E%3D+13.1%2C+ChromeAndroid+%3E%3D+106%2C+Samsung+%3E%3D+17%2C+iOS+%3E%3D+13.1&region=NO)