### PR TITLE
fix: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dnbexperience/browserslist-config.git"
+  },
   "files": [
     "browserslist.cjs",
     "supportedBrowsers.mjs",


### PR DESCRIPTION
This adds the `repository` field to package.json, making it easier to find the source code via `npm view @dnb/browserslist-config repository.url`.

Related to WEBC-2970