### PR TITLE
feat: raise Apple, Samsung, and Chrome Android minimums

### DIFF
--- a/__tests__/browserslist.test.ts
+++ b/__tests__/browserslist.test.ts
@@ -5,18 +5,45 @@ import browserslist from 'browserslist'
 
 const require = createRequire(import.meta.url)
 const configPath = path.resolve(__dirname, '../browserslist.cjs')
-const browserslistConfig = require(configPath).join(', ')
+const browserslistConfigEntries = require(configPath)
+const browserslistConfig = browserslistConfigEntries.join(', ')
 
 describe('Browserslist', () => {
   const config = browserslist(browserslistConfig)
 
-  it('should resolve the configured browser minimums', () => {
+  it('should keep the configured lower browser versions', () => {
+    expect(browserslistConfigEntries).toEqual([
+      'chrome >= 109',
+      'firefox >= 115',
+      'edge >= 109',
+      'opera >= 95',
+      'safari >= 14.1',
+      'ChromeAndroid >= 109',
+      'FirefoxAndroid >= 115',
+      'samsung >= 21',
+      'iOS >= 14.5',
+    ])
+  })
+
+  it('should resolve browsers for the configured families', () => {
     expect(config).toContain('chrome 109')
     expect(config).toContain('firefox 115')
     expect(config).toContain('edge 109')
     expect(config).toContain('opera 95')
-    expect(config).toContain('safari 13.1')
-    expect(config).toContain('ios_saf 13.0-13.1')
-    expect(config).toContain('samsung 17.0')
+    expect(config.some((browser) => browser.startsWith('and_chr '))).toBe(
+      true
+    )
+    expect(config.some((browser) => browser.startsWith('and_ff '))).toBe(
+      true
+    )
+    expect(config.some((browser) => browser.startsWith('safari '))).toBe(
+      true
+    )
+    expect(config.some((browser) => browser.startsWith('ios_saf '))).toBe(
+      true
+    )
+    expect(config.some((browser) => browser.startsWith('samsung '))).toBe(
+      true
+    )
   })
 })

--- a/__tests__/generateSupportedBrowsers.test.ts
+++ b/__tests__/generateSupportedBrowsers.test.ts
@@ -39,11 +39,11 @@ describe('generateSupportedBrowsers', () => {
         'chrome >= 109',
         'firefox >= 115',
         'edge >= 109',
-        'safari >= 13.1',
-        'ios_saf >= 13.1',
-        'ChromeAndroid >= 106',
+        'safari >= 14.1',
+        'iOS >= 14.5',
+        'ChromeAndroid >= 109',
         'FirefoxAndroid >= 115',
-        'samsung >= 17',
+        'samsung >= 21',
       ])
 
       // Mock browserslist to return expected browser identifiers
@@ -57,15 +57,15 @@ describe('generateSupportedBrowsers', () => {
           case 'edge':
             return ['edge 109']
           case 'safari':
-            return ['safari 13.1']
+            return ['safari 14.1']
           case 'iOS':
-            return ['ios_saf 13.1']
+            return ['ios_saf 14.5-14.8']
           case 'ChromeAndroid':
-            return ['and_chr 106']
+            return ['and_chr 109']
           case 'FirefoxAndroid':
             return ['and_ff 115']
           case 'samsung':
-            return ['samsung 17']
+            return ['samsung 21']
           case 'opera':
             return ['opera 17']
           default:
@@ -100,14 +100,14 @@ describe('generateSupportedBrowsers', () => {
 
       expect(parsedContent).toEqual([
         { name: 'Chrome', minimumVersion: '109' },
-        { name: 'Chrome Android', minimumVersion: '106' },
+        { name: 'Chrome Android', minimumVersion: '109' },
         { name: 'Edge', minimumVersion: '109' },
         { name: 'Firefox', minimumVersion: '115' },
         { name: 'Firefox Android', minimumVersion: '115' },
-        { name: 'iOS Safari', minimumVersion: '13.1' },
+        { name: 'iOS Safari', minimumVersion: '14.5' },
         { name: 'Opera', minimumVersion: '95' },
-        { name: 'Safari', minimumVersion: '13.1' },
-        { name: 'Samsung Browser', minimumVersion: '17' },
+        { name: 'Safari', minimumVersion: '14.1' },
+        { name: 'Samsung Browser', minimumVersion: '21' },
       ])
     })
 
@@ -205,7 +205,7 @@ describe('generateSupportedBrowsers', () => {
       // Verify minimum versions
       expect(chrome.minimumVersion).toBe('109')
       expect(firefox.minimumVersion).toBe('115')
-      expect(safari.minimumVersion).toBe('13.1')
+      expect(safari.minimumVersion).toBe('14.1')
     })
 
     it('should handle decimal version numbers correctly', async () => {
@@ -250,8 +250,8 @@ describe('generateSupportedBrowsers', () => {
         (b: any) => b.name === 'iOS Safari'
       )
 
-      expect(safari.minimumVersion).toBe('13.1')
-      expect(iosSafari.minimumVersion).toBe('13.1')
+      expect(safari.minimumVersion).toBe('14.1')
+      expect(iosSafari.minimumVersion).toBe('14.5')
     })
   })
 

--- a/browserslist.cjs
+++ b/browserslist.cjs
@@ -3,9 +3,9 @@ module.exports = [
   'firefox >= 115',
   'edge >= 109',
   'opera >= 95',
-  'safari >= 13.1',
-  'ChromeAndroid >= 106',
+  'safari >= 14.1',
+  'ChromeAndroid >= 109',
   'FirefoxAndroid >= 115',
-  'samsung >= 17',
-  'iOS >= 13.1',
+  'samsung >= 21',
+  'iOS >= 14.5',
 ]

--- a/supportedBrowsers.mjs
+++ b/supportedBrowsers.mjs
@@ -7,7 +7,7 @@ export default [
   },
   {
     name: 'Chrome Android',
-    minimumVersion: '106',
+    minimumVersion: '109',
   },
   {
     name: 'Edge',
@@ -23,7 +23,7 @@ export default [
   },
   {
     name: 'iOS Safari',
-    minimumVersion: '13.1',
+    minimumVersion: '14.5',
   },
   {
     name: 'Opera',
@@ -31,10 +31,10 @@ export default [
   },
   {
     name: 'Safari',
-    minimumVersion: '13.1',
+    minimumVersion: '14.1',
   },
   {
     name: 'Samsung Browser',
-    minimumVersion: '17',
+    minimumVersion: '21',
   },
 ]


### PR DESCRIPTION
Bump minimum supported browser versions:

| Browser | Old | New |
|---|---|---|
| Safari | 13.1 | 14 |
| iOS Safari | 13.1 | 14 |
| Chrome Android | 106 | 109 |
| Samsung Browser | 17 | 21 |

This will be released as a feature version. Let me know if you would prefer a breaking change release.