### PR TITLE
feat: add build targets for Vite, esbuild, and other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,41 @@ import supportedBrowsers from '@dnb/browserslist-config/supportedBrowsers.mjs'
 // Will output an array with an object for each browser, containing "name" and "minimumVersion".
 ```
 
+## Build targets for Vite, esbuild, and other tools
+
+Tools like Vite and esbuild do not read browserslist configuration. This package provides pre-built target strings compatible with these tools:
+
+```ts
+import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'
+
+// Returns e.g. ['chrome106', 'edge109', 'firefox115', 'ios13.1', 'opera95', 'safari13.1']
+```
+
+Use with Vite:
+
+```ts
+import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'
+
+export default defineConfig({
+  build: {
+    target: buildTargets,
+  },
+})
+```
+
+Use with esbuild:
+
+```ts
+import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'
+
+await esbuild.build({
+  target: buildTargets,
+  // ...
+})
+```
+
+> **Note:** Samsung Browser is excluded from build targets as it has no esbuild equivalent. Families that share an engine are merged — e.g. Chrome and Chrome Android produce a single `chrome` target using the lower version.
+
 ## Development
 
 ### Use git commit message descriptions

--- a/__tests__/buildTargets.test.ts
+++ b/__tests__/buildTargets.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { getBuildTargets } from '../generateSupportedBrowsers'
+import buildTargets from '../buildTargets.mjs'
+
+describe('buildTargets', () => {
+  it('should stay in sync with the generated build targets', () => {
+    expect(buildTargets).toEqual(getBuildTargets())
+  })
+
+  it('should contain only valid esbuild target strings', () => {
+    const validPrefixes = [
+      'chrome',
+      'edge',
+      'firefox',
+      'ios',
+      'opera',
+      'safari',
+    ]
+
+    buildTargets.forEach((target: string) => {
+      const hasValidPrefix = validPrefixes.some((prefix) =>
+        target.startsWith(prefix)
+      )
+      expect(hasValidPrefix).toBe(true)
+
+      // After removing the prefix, the remainder should be a version number
+      const prefix = validPrefixes.find((p) => target.startsWith(p))
+      const version = target.slice(prefix!.length)
+      expect(version).toMatch(/^\d+(\.\d+)?$/)
+    })
+  })
+
+  it('should merge families that share an engine', () => {
+    // chrome and ChromeAndroid should produce a single "chrome" target
+    const chromeTargets = buildTargets.filter((t: string) =>
+      t.startsWith('chrome')
+    )
+    expect(chromeTargets).toHaveLength(1)
+
+    // firefox and FirefoxAndroid should produce a single "firefox" target
+    const firefoxTargets = buildTargets.filter((t: string) =>
+      t.startsWith('firefox')
+    )
+    expect(firefoxTargets).toHaveLength(1)
+  })
+
+  it('should not include samsung (no esbuild equivalent)', () => {
+    const samsungTargets = buildTargets.filter((t: string) =>
+      t.startsWith('samsung')
+    )
+    expect(samsungTargets).toHaveLength(0)
+  })
+
+  it('should be sorted alphabetically', () => {
+    const sorted = [...buildTargets].sort()
+    expect(buildTargets).toEqual(sorted)
+  })
+})

--- a/__tests__/generateSupportedBrowsers.test.ts
+++ b/__tests__/generateSupportedBrowsers.test.ts
@@ -263,7 +263,13 @@ describe('generateSupportedBrowsers', () => {
       await generateBrowsersFile()
 
       const writeFileCalls = vi.mocked(writeFile).mock.calls
-      expect(writeFileCalls[0][0]).toMatch(/supportedBrowsers\.mjs$/)
+      const writtenPaths = writeFileCalls.map(([path]) => String(path))
+      expect(writtenPaths).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/supportedBrowsers\.mjs$/),
+          expect.stringMatching(/buildTargets\.mjs$/),
+        ])
+      )
     })
 
     it('should include auto-generated comment', async () => {
@@ -273,10 +279,11 @@ describe('generateSupportedBrowsers', () => {
       await generateBrowsersFile()
 
       const writeFileCalls = vi.mocked(writeFile).mock.calls
-      const writtenContent = writeFileCalls[0][1] as string
-      expect(writtenContent).toMatch(
-        /\/\/ This file is auto-generated\. Do not edit directly\./
-      )
+      for (const [, content] of writeFileCalls) {
+        expect(String(content)).toMatch(
+          /\/\/ This file is auto-generated\. Do not edit directly\./
+        )
+      }
     })
 
     it('should handle prettier config file not found', async () => {

--- a/buildTargets.mjs
+++ b/buildTargets.mjs
@@ -1,0 +1,10 @@
+// This file is auto-generated. Do not edit directly.
+
+export default [
+  'chrome109',
+  'edge109',
+  'firefox115',
+  'ios14.5',
+  'opera95',
+  'safari14.1',
+]

--- a/generateSupportedBrowsers.ts
+++ b/generateSupportedBrowsers.ts
@@ -17,6 +17,20 @@ export const browsers: Record<string, string> = {
   samsung: 'Samsung Browser',
 }
 
+// Maps browserslist family names to esbuild/Vite target names.
+// Families that share an engine are merged (e.g. ChromeAndroid → chrome).
+// Samsung Browser has no esbuild equivalent and is omitted.
+const esbuildTargetMap: Record<string, string> = {
+  chrome: 'chrome',
+  ChromeAndroid: 'chrome',
+  edge: 'edge',
+  firefox: 'firefox',
+  FirefoxAndroid: 'firefox',
+  iOS: 'ios',
+  opera: 'opera',
+  safari: 'safari',
+}
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
@@ -43,15 +57,32 @@ export function getSupportedBrowsers(): Browser[] {
     .sort((a, b) => a?.name?.localeCompare(b?.name))
 }
 
+export function getBuildTargets(): string[] {
+  const targets: Record<string, string> = {}
+
+  for (const entry of browserslistConfig) {
+    const [family, version] = entry.split(/\s*[>=<]+\s*/)
+    const target = esbuildTargetMap[family]
+    if (!target) continue
+
+    // When multiple families map to the same target (e.g. chrome + ChromeAndroid),
+    // keep the lower version so the output is compatible with both.
+    if (
+      !targets[target] ||
+      parseFloat(version) < parseFloat(targets[target])
+    ) {
+      targets[target] = version
+    }
+  }
+
+  return Object.entries(targets)
+    .map(([target, version]) => `${target}${version}`)
+    .sort()
+}
+
 export async function generateBrowsersFile() {
   const browsers = getSupportedBrowsers()
-
-  const outputPath = resolve(__dirname, './supportedBrowsers.mjs')
-
-  const content = `// This file is auto-generated. Do not edit directly.
-
-export default ${JSON.stringify(browsers, null, 2)};
-`
+  const buildTargets = getBuildTargets()
 
   // Read .prettierrc file
   const prettierConfigPath = resolve(process.cwd(), '.prettierrc')
@@ -59,14 +90,26 @@ export default ${JSON.stringify(browsers, null, 2)};
     (await readFile(prettierConfigPath, 'utf-8')) || '[]'
   )
 
-  // Format the content using Prettier with .prettierrc config
-  const formattedContent = await prettier.format(content, {
-    ...prettierConfig,
-    parser: 'babel',
-    filepath: outputPath,
-  })
+  const formatAndWrite = async (filePath: string, raw: string) => {
+    const formatted = await prettier.format(raw, {
+      ...prettierConfig,
+      parser: 'babel',
+      filepath: filePath,
+    })
+    await writeFile(filePath, formatted, 'utf-8')
+  }
 
-  await writeFile(outputPath, formattedContent, 'utf-8')
+  const supportedPath = resolve(__dirname, './supportedBrowsers.mjs')
+  await formatAndWrite(
+    supportedPath,
+    `// This file is auto-generated. Do not edit directly.\n\nexport default ${JSON.stringify(browsers, null, 2)};\n`
+  )
+
+  const targetsPath = resolve(__dirname, './buildTargets.mjs')
+  await formatAndWrite(
+    targetsPath,
+    `// This file is auto-generated. Do not edit directly.\n\nexport default ${JSON.stringify(buildTargets)};\n`
+  )
 }
 
 // Exported for testing

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "files": [
     "browserslist.cjs",
     "supportedBrowsers.mjs",
+    "buildTargets.mjs",
     "README.md",
     "LICENSE",
     "package.json"
@@ -27,7 +28,7 @@
     "release:dry": "dotenv semantic-release --no-ci --dry-run",
     "lint:fix": "prettier --write .",
     "build": "tsx generateSupportedBrowsers.ts",
-    "check:generated": "yarn build && git diff --exit-code -- supportedBrowsers.mjs",
+    "check:generated": "yarn build && git diff --exit-code -- supportedBrowsers.mjs buildTargets.mjs",
     "build:watch": "tsx watch generateSupportedBrowsers.ts",
     "prepublishOnly": "yarn build",
     "prepare": "yarn build"


### PR DESCRIPTION
Adds a new `buildTargets.mjs` export with esbuild/Vite-compatible target strings derived from the browserslist config.

### Usage

```ts
import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'

// Vite
export default defineConfig({ build: { target: buildTargets } })

// esbuild
await esbuild.build({ target: buildTargets })
```

### Details

- Families sharing an engine are merged — e.g. Chrome + Chrome Android → single `chrome` target using the lower version
- Samsung Browser is excluded (no esbuild equivalent)
- The file is auto-generated alongside `supportedBrowsers.mjs` during `yarn build`
- README updated with usage examples